### PR TITLE
Updating default base URL to be the root URI.

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ import svgr from "vite-plugin-svgr";
  * @see https://vitest.dev/config/
  */
 export default defineConfig({
-  base: "/bgg-what-to-play/",
+  base: "/",
   plugins: [react(), svgr()],
   resolve: {
     alias: {


### PR DESCRIPTION
By default, the application uses a subdirectory (/bgg-what-to-play/).

This updates the build config to be the root for CloudFlare pages.